### PR TITLE
Rename to just ios

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 We :heart: and encourage all contributions from the community. Here is how you can get involved and help make FetLife for iOS better.
 
-If you haven't already, build and run the application by following the instructions in the [README](https://github.com/fetlife/fetlife-ios#building-the-application).
+If you haven't already, build and run the application by following the instructions in the [README](https://github.com/fetlife/ios#building-the-application).
 
 ## Reporting a bug
 
-If you've found a problem with the app. Please browse through the [GitHub issues](https://github.com/fetlife/fetlife-ios/issues) to see if your issue is being worked on or has been previously reported. If your issue is brand new, :bug: :sparkles: don't by shy. Add a [new issue](https://github.com/fetlife/fetlife-ios/issues/new).
+If you've found a problem with the app. Please browse through the [GitHub issues](https://github.com/fetlife/ios/issues) to see if your issue is being worked on or has been previously reported. If your issue is brand new, :bug: :sparkles: don't by shy. Add a [new issue](https://github.com/fetlife/ios/issues/new).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ These instructions are written assuming you know very little about computers and
 2. Open the `Terminal` application up on your Mac.
 3. Enter the following commands into your terminal window one by one and wait for them to finish:
   - `sudo gem install cocoapods` you will be prompted for your computers password
-  - `git clone git@github.com:fetlife/fetlife-ios.git`
-  - `cd fetlife-ios`
+  - `git clone git@github.com:fetlife/ios.git`
+  - `cd ios`
   - `pod install`
   - `open FetLife.xcworkspace`
 4. Installing the app on your phone:
@@ -53,7 +53,7 @@ Want to install the app on your phone but are not technically savvy? Ask your lo
 
 ### Got Bugs?
 
-If you find a bug please start by reading through the our current list of [open issues](https://github.com/fetlife/fetlife-ios/issues) and if you can't find anything about your bug please [submit a new bug](https://github.com/fetlife/fetlife-ios/issues/new).
+If you find a bug please start by reading through the our current list of [open issues](https://github.com/fetlife/ios/issues) and if you can't find anything about your bug please [submit a new bug](https://github.com/fetlife/ios/issues/new).
 
 
 ### Want to Contribute


### PR DESCRIPTION
Along with changing the name of the repository, we want to adjust any links to the old name.