### PR TITLE
fix: catch unexpectedSubscript when no avatar is set

### DIFF
--- a/FetLife/Models.swift
+++ b/FetLife/Models.swift
@@ -15,24 +15,28 @@ private let dateFormatter: DateFormatter = DateFormatter()
 // MARK: - Member
 
 class Member: Object, JSONDecodable {
-    let defaultAvatarURL = "https://flassets.a.ssl.fastly.net/images/avatar_missing_200x200.gif"
-    
+    let defaultAvatarURL = "https://ass3.fetlife.com/images/avatar_missing_200x200.gif"
+
     dynamic var id = ""
     dynamic var nickname = ""
     dynamic var metaLine = ""
     dynamic var avatarURL = ""
-    
+
     override static func primaryKey() -> String? {
         return "id"
     }
-    
+
     required convenience init(json: JSON) throws {
         self.init()
-        
+
         id = try json.getString(at: "id")
         nickname = try json.getString(at: "nickname")
         metaLine = try json.getString(at: "meta_line")
-        avatarURL = try json.getString(at: "avatar", "variants", "medium", or: defaultAvatarURL)
+        do {
+            avatarURL = try json.getString(at: "avatar", "variants", "medium", or: defaultAvatarURL)
+        } catch {
+            avatarURL = defaultAvatarURL
+        }
     }
 }
 
@@ -44,33 +48,33 @@ class Conversation: Object, JSONDecodable {
     dynamic var member: Member?
     dynamic var hasNewMessages = false
     dynamic var isArchived = false
-    
+
     dynamic var lastMessageBody = ""
     dynamic var lastMessageCreated = Date()
-    
+
     override static func primaryKey() -> String? {
         return "id"
     }
 
     required convenience init(json: JSON) throws {
         self.init()
-        
+
         id = try json.getString(at: "id")
         updatedAt = try dateStringToNSDate(json.getString(at: "updated_at"))!
         member = try json.decode(at: "member", type: Member.self)
         hasNewMessages = try json.getBool(at: "has_new_messages")
         isArchived = try json.getBool(at: "is_archived")
-        
+
         if let lastMessage = json["last_message"] {
             lastMessageBody = try decodeHTML(lastMessage.getString(at: "body"))
             lastMessageCreated = try dateStringToNSDate(lastMessage.getString(at: "created_at"))!
         }
     }
-    
+
     func summary() -> String {
         return lastMessageBody
     }
-    
+
     func timeAgo() -> String {
         return (lastMessageCreated as NSDate).shortTimeAgoSinceNow()
     }
@@ -88,14 +92,14 @@ class Message: Object {
     dynamic var isNew = false
     dynamic var isSending = false
     dynamic var conversationId = ""
-    
+
     override static func primaryKey() -> String? {
         return "id"
     }
-    
+
     required convenience init(json: JSON) throws {
         self.init()
-        
+
         id = try json.getString(at: "id")
         body = try decodeHTML(json.getString(at: "body"))
         createdAt = try dateStringToNSDate(json.getString(at: "created_at"))!
@@ -121,14 +125,14 @@ private func decodeHTML(_ htmlEncodedString: String) -> String {
         NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType as AnyObject,
         NSCharacterEncodingDocumentAttribute: NSNumber(value: String.Encoding.utf8.rawValue) as AnyObject
     ]
-    
+
     var attributedString:NSAttributedString?
-    
+
     do {
         attributedString = try NSAttributedString(data: encodedData, options: attributedOptions, documentAttributes: nil)
     } catch {
         print(error)
     }
-    
+
     return attributedString!.string
 }


### PR DESCRIPTION
### Summary

Given a user has no avatar set yet (new user) the app crashed due to an unexpectedSubscript error from Freddy because the avatar could not be extracted from the API response. See https://github.com/bignerdranch/Freddy/wiki/Error-Handling#unexpected-subscript

I've also updated the default avatar URL since the old one did no longer work and removed trailing spaces.