### PR TITLE
update Readme w/ instruction to prevent permission errons on /usr/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These instructions are written assuming you know very little about computers and
 1. Install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12).
 2. Open the `Terminal` application up on your Mac.
 3. Enter the following commands into your terminal window one by one and wait for them to finish:
-  - `sudo gem install cocoapods` you will be prompted for your computers password
+  - `sudo gem install -n /usr/local/bin cocoapods` you will be prompted for your computers password
   - `git clone git@github.com:fetlife/ios.git`
   - `cd ios`
   - `pod install`


### PR DESCRIPTION
### Summary
I updated the readme statement for installing the cocoapods w/ the -n switch.
This should prevent writing permission errors due its try to install directly in to 
/usr/bin which is forbidden for everyone, including root.
### Other Information
See Stackoverflow https://stackoverflow.com/questions/49213136/you-dont-have-write-permissions-for-the-usr-bin-directory-when-installing-s
_The default directory (/usr/bin) is not writeable due protected by system integrity protection and is not writeable by anybody even root._ 
